### PR TITLE
Fix hardcoded model name in test_model_profiles

### DIFF
--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -29,13 +29,16 @@ class ModelProfileResolverTests(unittest.TestCase):
         self.assertIsNone(resolver.resolve("bogus"))
 
     def test_resolve_returns_correct_coding_profile(self) -> None:
+        raw = json.loads(REAL_CONFIG_PATH.read_text(encoding="utf-8"))
+        expected = next(p for p in raw["profiles"] if p["phase"] == "coding")
+
         resolver = ModelProfileResolver(REAL_CONFIG_PATH)
         profile = resolver.resolve("coding")
-        self.assertEqual(profile.provider, "zhipu")
-        self.assertEqual(profile.model, "glm-4.5")
-        self.assertEqual(profile.max_tokens, 65536)
-        self.assertAlmostEqual(profile.temperature, 0.1)
-        self.assertEqual(profile.timeout_s, 600)
+        self.assertEqual(profile.provider, expected["provider"])
+        self.assertEqual(profile.model, expected["model"])
+        self.assertEqual(profile.max_tokens, expected["max_tokens"])
+        self.assertAlmostEqual(profile.temperature, expected["temperature"])
+        self.assertEqual(profile.timeout_s, expected["timeout_s"])
 
     def test_fallback_when_failed_true(self) -> None:
         resolver = ModelProfileResolver(REAL_CONFIG_PATH)


### PR DESCRIPTION
## Summary

- `test_resolve_returns_correct_coding_profile` was hardcoding `"glm-4.7"` (then `"glm-4.5"`), which breaks CI every time the team changes models
- Now reads expected values directly from `model_profiles.json`, so the test validates that the resolver **correctly parses the config** rather than asserting a specific model string
- Model changes will no longer break CI

## What changed

One test method in `tests/test_model_profiles.py` — reads the config file and compares against it instead of hardcoded values.

## Test plan

- [x] All 12 model profile tests pass locally
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)