### PR TITLE
Fix /new session isolation and reconcile pipeline state from artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ workspace/hackathon/progress.md
 workspace/hackathon/research_summary.md
 workspace/hackathon/project/
 workspace/hackathon/submission/
+tests/
 
 # Agent runtime state
 workspace/.cron/

--- a/0xclaw/config/config.json
+++ b/0xclaw/config/config.json
@@ -13,7 +13,7 @@
   "providers": {
     "acp": {
       "agent": "claude",
-      "modelId": "qwen3.5-plus",
+      "modelId": "glm-5.1",
       "cwd": "./workspace",
       "sessionName": "0xclaw",
       "timeoutSec": 1800,
@@ -43,7 +43,7 @@
     },
     "claudeCode": {
       "agent": "claude",
-      "modelId": "qwen3.5-plus",
+      "modelId": "glm-5.1",
       "cwd": "./workspace/hackathon/project",
       "sessionName": "0xclaw-coder",
       "timeoutSec": 1800,

--- a/0xclaw/main.py
+++ b/0xclaw/main.py
@@ -12,6 +12,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from itertools import count
 
 from loguru import logger
 from dotenv import load_dotenv
@@ -42,17 +43,18 @@ from orchestration.model_profiles import ModelProfileResolver
 from orchestration.phase_completion import (
     clear_marker,
     detect_failure_reason,
-    is_phase_complete,
     marker_path,
     output_exists as phase_output_exists,
     write_marker,
 )
-from orchestration.router import SkillRouter
+from orchestration.router import SkillRouter, keyword_matches
 from orchestration.session_control import SessionControl
 from orchestration.state import (
     COMPLETED_PHASE_STATUSES,
     OrchestratorStateMachine,
     PipelineStateStore,
+    phase_completion_ready,
+    reconcile_pipeline_state,
 )
 from orchestration.write_guard import build_phase_write_guard, install_phase_write_guards
 
@@ -329,7 +331,7 @@ def _show_pipeline_status(state_store: PipelineStateStore) -> None:
         "pending":   ("[dim]○[/dim]",          "pending",   "dim"),
     }
     try:
-        state = state_store.load()
+        state = reconcile_pipeline_state(state_store)
     except Exception:
         console.print("[dim]No pipeline state found. Run a phase to begin.[/dim]")
         return
@@ -366,13 +368,13 @@ def _output_exists(path: Path | None) -> bool:
 
 def _fallback_classifier(text: str) -> str | None:
     t = text.lower()
-    if "plan" in t or "规划" in t:
+    if keyword_matches("plan", t) or keyword_matches("规划", t):
         return "planning"
-    if "test" in t or "测试" in t:
+    if keyword_matches("test", t) or keyword_matches("测试", t):
         return "testing"
-    if "doc" in t or "文档" in t:
+    if keyword_matches("doc", t) or keyword_matches("文档", t):
         return "doc"
-    if "code" in t or "实现" in t:
+    if keyword_matches("code", t) or keyword_matches("实现", t):
         return "coding"
     return None
 
@@ -396,11 +398,7 @@ def _is_background_handoff_progress(text: str) -> bool:
 def _phase_is_complete(phase: str | None) -> bool:
     if not phase:
         return False
-    return is_phase_complete(
-        phase,
-        hackathon_dir=HACKATHON_DIR,
-        phase_output=PHASE_OUTPUTS.get(phase),
-    )
+    return phase_completion_ready(HACKATHON_DIR, phase)
 
 
 def _prepare_phase_run(phase: str) -> None:
@@ -419,6 +417,15 @@ class SendWaitResult:
     response: str
     timed_out: bool = False
     background_handoff: bool = False
+
+
+def _turn_request_id(sequence: int) -> str:
+    return f"cli-turn-{sequence}"
+
+
+def _matches_active_request(request_id: str | None, active_request_id: str | None) -> bool:
+    """Return True when an outbound message belongs to the currently awaited turn."""
+    return not request_id or request_id == active_request_id
 
 
 def _finalize_phase_run(
@@ -442,7 +449,7 @@ def _finalize_phase_run(
     if primary_output_ready:
         _mark_phase_complete(phase, trace_id)
 
-    if _phase_is_complete(phase):
+    if state_machine.phase_is_complete(phase):
         state_machine.checkpoint(phase, "done")
         return None, False
 
@@ -672,6 +679,9 @@ def _reset_workspace_runtime_outputs() -> list[str]:
         elif p.exists():
             p.unlink()
             removed.append(f"workspace/{rel}")
+    from runtime.agent.memory import MemoryStore as _MemoryStore
+
+    _MemoryStore(WORKSPACE).reset()
     return removed
 
 
@@ -840,6 +850,8 @@ async def run_interactive(config: Config) -> None:
     turn_done.set()
     turn_response: list[str] = []
     turn_saw_background_handoff = [False]
+    request_counter = count(1)
+    active_request_id: str | None = None
 
     # ── Ctrl+C handling — never exits, only interrupts the current task ────────
     _processing = [False]   # mutable so the signal handler closure can read it
@@ -867,9 +879,13 @@ async def run_interactive(config: Config) -> None:
 
     async def _consume():
         """Drain the outbound bus. Releases prompt as soon as agent replies."""
+        nonlocal active_request_id
         while True:
             try:
                 msg = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+                request_id = (msg.metadata or {}).get("request_id")
+                if not _matches_active_request(request_id, active_request_id):
+                    continue
                 if msg.metadata.get("_progress"):
                     if _is_background_handoff_progress(msg.content or ""):
                         turn_saw_background_handoff[0] = True
@@ -920,26 +936,38 @@ async def run_interactive(config: Config) -> None:
         timeout_s: int = DEFAULT_PHASE_TIMEOUT_S,
         phase: str | None = None,
     ) -> SendWaitResult:
+        nonlocal active_request_id
         _processing[0] = True
         turn_done.clear()
         turn_response.clear()
         turn_saw_background_handoff[0] = False
+        active_request_id = _turn_request_id(next(request_counter))
         await bus.publish_inbound(InboundMessage(
-            channel="cli", sender_id="user", chat_id="direct", content=text, metadata={"phase": phase} if phase else {},
+            channel="cli",
+            sender_id="user",
+            chat_id="direct",
+            content=text,
+            metadata={
+                **({"phase": phase} if phase else {}),
+                "request_id": active_request_id,
+            },
         ))
         try:
             with console.status("[dim]0xClaw is thinking…[/dim]", spinner="dots"):
                 await asyncio.wait_for(turn_done.wait(), timeout=timeout_s)
         except asyncio.TimeoutError:
             turn_done.set()
-            console.print(f"[yellow]Timed out after {timeout_s}s.[/yellow]")
+            active_request_id = None
+            console.print(f"[yellow]Timed out after {timeout_s}s waiting for agent confirmation.[/yellow]")
             return SendWaitResult("", timed_out=True, background_handoff=turn_saw_background_handoff[0])
         finally:
             _processing[0] = False
-        return SendWaitResult(
+        result = SendWaitResult(
             turn_response[0] if turn_response else "",
             background_handoff=turn_saw_background_handoff[0],
         )
+        active_request_id = None
+        return result
 
     async def _send_and_wait_traced(
         text: str,

--- a/0xclaw/orchestration/router.py
+++ b/0xclaw/orchestration/router.py
@@ -78,7 +78,7 @@ class RouteDecision:
     source: str
 
 
-def _keyword_matches(keyword: str, text: str) -> bool:
+def keyword_matches(keyword: str, text: str) -> bool:
     """Match keyword against text.
 
     Multi-word keywords use simple substring matching.
@@ -108,7 +108,7 @@ class SkillRouter:
         phase_scores: dict[str, int] = {}
         matched_keywords: dict[str, str] = {}
         for phase, keys in KEYWORD_MAP.items():
-            matched = [k for k in keys if _keyword_matches(k, text)]
+            matched = [k for k in keys if keyword_matches(k, text)]
             if not matched:
                 continue
             # Prefer more specific matches, e.g. "select idea" over the generic "idea".

--- a/0xclaw/orchestration/session_control.py
+++ b/0xclaw/orchestration/session_control.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .state import COMPLETED_PHASE_STATUSES, PHASE_PRIMARY_OUTPUTS, PHASES, PipelineStateStore
-from .phase_completion import output_exists
+from .state import (
+    COMPLETED_PHASE_STATUSES,
+    PHASES,
+    PipelineStateStore,
+    reconcile_pipeline_state,
+)
 
 
 PHASE_TO_COMMAND = {
@@ -34,7 +38,7 @@ class SessionControl:
         return self.store.set_phase_status(phase, "cancelled", last_error=reason)
 
     def get_resume_decision(self) -> ResumeDecision:
-        state = self.store.load()
+        state = reconcile_pipeline_state(self.store)
         status_map = {row["name"]: row["status"] for row in state["phases"]}
 
         current = state.get("current_phase")
@@ -52,23 +56,6 @@ class SessionControl:
             for p in PHASES[idx + 1:]:
                 if status_map.get(p) not in COMPLETED_PHASE_STATUSES:
                     return ResumeDecision(p, PHASE_TO_COMMAND[p], f"Resume from next phase after {checkpoint}")
-
-        # Auto-heal: if state file is missing or stale, check actual output files
-        healed = False
-        for phase, primary_output in PHASE_PRIMARY_OUTPUTS.items():
-            if status_map.get(phase) not in COMPLETED_PHASE_STATUSES:
-                out_path = self.store.hackathon_dir / primary_output
-                if output_exists(out_path):
-                    self.store.set_phase_status(phase, "done")
-                    status_map[phase] = "done"
-                    healed = True
-
-        if healed:
-            # Re-evaluate after healing — skip to first genuinely incomplete phase
-            for p in PHASES:
-                if status_map.get(p) not in COMPLETED_PHASE_STATUSES:
-                    return ResumeDecision(p, PHASE_TO_COMMAND[p], "Resume from first incomplete phase")
-            return ResumeDecision(None, None, "All phases are complete")
 
         for p in PHASES:
             if status_map.get(p) not in COMPLETED_PHASE_STATUSES:

--- a/0xclaw/orchestration/state.py
+++ b/0xclaw/orchestration/state.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .phase_completion import is_phase_complete as phase_output_is_complete
 from .phase_completion import output_exists
 
 PHASES = ("research", "idea", "selection", "planning", "coding", "testing", "doc")
@@ -41,6 +42,16 @@ PHASE_PRIMARY_OUTPUTS: dict[str, str] = {
     "doc": "submission/README.md",
 }
 
+PHASE_COMPLETION_ARTIFACTS: dict[str, tuple[str, ...]] = {
+    "research": ("context.json",),
+    "idea": ("ideas.json",),
+    "selection": ("selected_idea.json",),
+    "planning": ("plan.md", "tasks.json"),
+    "coding": ("project",),
+    "testing": ("test_results.json",),
+    "doc": ("submission/README.md",),
+}
+
 PHASE_ALLOWED_WRITE_DIRS: dict[str, tuple[str, ...]] = {
     "research": ("hackathon/context.json", "hackathon/pipeline_state.json", "hackathon/progress.md"),
     "idea": ("hackathon/ideas.json", "hackathon/pipeline_state.json", "hackathon/progress.md"),
@@ -50,6 +61,10 @@ PHASE_ALLOWED_WRITE_DIRS: dict[str, tuple[str, ...]] = {
     "testing": ("hackathon/test_results.json", "hackathon/pipeline_state.json", "hackathon/progress.md"),
     "doc": ("hackathon/submission", "hackathon/pipeline_state.json", "hackathon/progress.md"),
 }
+
+PROTECTED_PIPELINE_PATHS = tuple(
+    dict.fromkeys(path for paths in PHASE_ALLOWED_WRITE_DIRS.values() for path in paths)
+)
 
 COMPLETED_PHASE_STATUSES = frozenset({"done", "complete"})
 
@@ -69,6 +84,30 @@ def _default_state() -> dict:
     }
 
 
+def _normalize_state(data: dict | None) -> dict:
+    """Hydrate a possibly stale or partial state file into the current schema."""
+    base = _default_state()
+    if not isinstance(data, dict):
+        return base
+
+    state = dict(base)
+    state.update({k: v for k, v in data.items() if k != "phases"})
+
+    existing_rows = {}
+    for row in data.get("phases", []) if isinstance(data.get("phases"), list) else []:
+        if isinstance(row, dict) and row.get("name") in PHASES:
+            existing_rows[row["name"]] = row
+
+    normalized_rows = []
+    for default_row in base["phases"]:
+        row = dict(default_row)
+        row.update(existing_rows.get(default_row["name"], {}))
+        normalized_rows.append(row)
+
+    state["phases"] = normalized_rows
+    return state
+
+
 class PipelineStateStore:
     """File-backed pipeline state store."""
 
@@ -81,7 +120,7 @@ class PipelineStateStore:
         if not self.path.exists():
             return _default_state()
         data = json.loads(self.path.read_text(encoding="utf-8"))
-        return data
+        return _normalize_state(data)
 
     def save(self, state: dict) -> None:
         state["updated_at"] = _utc_now()
@@ -107,6 +146,76 @@ class PipelineStateStore:
         return state
 
 
+def phase_completion_paths(hackathon_dir: Path, phase: str) -> tuple[Path, ...]:
+    """Return the artifact paths that define phase completion."""
+    return tuple(hackathon_dir / rel for rel in PHASE_COMPLETION_ARTIFACTS.get(phase, ()))
+
+
+def phase_completion_ready(hackathon_dir: Path, phase: str) -> bool:
+    """Return True when the phase's required completion artifacts exist."""
+    if phase == "coding":
+        output = hackathon_dir / PHASE_PRIMARY_OUTPUTS["coding"]
+        return phase_output_is_complete("coding", hackathon_dir=hackathon_dir, phase_output=output)
+    paths = phase_completion_paths(hackathon_dir, phase)
+    return bool(paths) and all(output_exists(path) for path in paths)
+
+
+def reconcile_pipeline_state(store: PipelineStateStore, *, persist: bool = True) -> dict:
+    """Reconcile pipeline_state.json against actual hackathon artifacts.
+
+    The highest phase with completion artifacts becomes the effective checkpoint,
+    and all earlier phases are treated as complete to avoid impossible gaps like
+    planning=done with selection=pending.
+    """
+    state = store.load()
+    rows = {row["name"]: row for row in state["phases"]}
+    highest_complete_idx = -1
+
+    for idx, phase in enumerate(PHASES):
+        if phase_completion_ready(store.hackathon_dir, phase):
+            highest_complete_idx = idx
+
+    changed = False
+    if highest_complete_idx >= 0:
+        for idx, phase in enumerate(PHASES):
+            row = rows[phase]
+            status = row.get("status", "pending")
+            if idx <= highest_complete_idx:
+                desired = "done"
+            elif status in COMPLETED_PHASE_STATUSES:
+                desired = "pending"
+            else:
+                desired = status
+
+            if desired != status:
+                row["status"] = desired
+                row["updated_at"] = _utc_now()
+                changed = True
+
+        current_phase = state.get("current_phase")
+        if current_phase not in PHASES or rows[current_phase]["status"] != "running":
+            if state.get("current_phase") is not None:
+                changed = True
+            state["current_phase"] = None
+            if state.get("active_task") is not None:
+                changed = True
+            state["active_task"] = None
+
+        desired_checkpoint = PHASES[highest_complete_idx]
+        if state.get("last_checkpoint") != desired_checkpoint:
+            state["last_checkpoint"] = desired_checkpoint
+            changed = True
+
+        if not any(row.get("status") == "failed" for row in rows.values()) and state.get("last_error") is not None:
+            state["last_error"] = None
+            changed = True
+
+    state["phases"] = [rows[phase] for phase in PHASES]
+    if changed and persist:
+        store.save(state)
+    return state
+
+
 @dataclass(slots=True)
 class ValidationResult:
     ok: bool
@@ -126,17 +235,11 @@ class OrchestratorStateMachine:
         if phase not in PHASES:
             return ValidationResult(False, [f"Unknown phase: {phase}"])
 
-        state = self.store.load()
+        state = reconcile_pipeline_state(self.store)
         status_map = {row["name"]: row["status"] for row in state["phases"]}
 
         for dep in PHASE_DEPENDENCIES[phase]:
             if status_map.get(dep) not in COMPLETED_PHASE_STATUSES:
-                primary_output = PHASE_PRIMARY_OUTPUTS.get(dep)
-                dep_output = self.hackathon_dir / primary_output if primary_output else None
-                if dep_output is not None and output_exists(dep_output):
-                    self.store.set_phase_status(dep, "done")
-                    status_map[dep] = "done"
-                    continue
                 errors.append(f"Dependency not complete: {dep}")
 
         for req in REQUIRED_ARTIFACTS[phase]:
@@ -145,6 +248,9 @@ class OrchestratorStateMachine:
                 errors.append(f"Missing required artifact: hackathon/{req}")
 
         return ValidationResult(not errors, errors)
+
+    def phase_is_complete(self, phase: str) -> bool:
+        return phase_completion_ready(self.hackathon_dir, phase)
 
     def is_write_allowed(self, phase: str, target_rel: str) -> bool:
         target = target_rel.strip("/")

--- a/0xclaw/orchestration/write_guard.py
+++ b/0xclaw/orchestration/write_guard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from .state import OrchestratorStateMachine
+from .state import OrchestratorStateMachine, PROTECTED_PIPELINE_PATHS
 
 WriteGuard = Callable[[str], str | None]
 PhaseGetter = Callable[[], str | None]
@@ -20,10 +20,6 @@ def build_phase_write_guard(
     workspace_root = workspace.resolve()
 
     def _guard(path: str) -> str | None:
-        phase = get_phase()
-        if not phase:
-            return None
-
         p = Path(path).expanduser()
         if not p.is_absolute():
             p = workspace_root / p
@@ -33,6 +29,17 @@ def build_phase_write_guard(
             rel = resolved.relative_to(workspace_root).as_posix()
         except ValueError:
             return f"Path '{path}' is outside workspace"
+
+        phase = get_phase()
+        if not phase:
+            for prefix in PROTECTED_PIPELINE_PATHS:
+                normalized = prefix.strip("/")
+                if rel == normalized or rel.startswith(normalized + "/"):
+                    return (
+                        f"Pipeline artifact '{rel}' cannot be written outside an active phase. "
+                        "Use the corresponding phase command or /resume."
+                    )
+            return None
 
         try:
             state_machine.assert_write_allowed(phase, rel)

--- a/0xclaw/runtime/agent/context.py
+++ b/0xclaw/runtime/agent/context.py
@@ -72,6 +72,8 @@ Your workspace is at: {workspace_path}
 - Custom skills: {workspace_path}/skills/{{skill-name}}/SKILL.md
 
 ## 0xClaw Guidelines
+- Only store durable cross-session memory such as user language, tone, framework/tooling preferences, and other stable preferences.
+- Do NOT store transient hackathon/project pipeline state in MEMORY.md; keep that in workspace output files under hackathon/.
 - State intent before tool calls, but NEVER predict or claim results before receiving them.
 - Before modifying a file, read it first. Do not assume files or directories exist.
 - After writing or editing a file, re-read it if accuracy matters.

--- a/0xclaw/runtime/agent/loop.py
+++ b/0xclaw/runtime/agent/loop.py
@@ -499,28 +499,8 @@ class AgentLoop:
         # Slash commands
         cmd = msg.content.strip().lower()
         if cmd == "/new":
-            lock = self._consolidation_locks.setdefault(session.key, asyncio.Lock())
-            self._consolidating.add(session.key)
-            try:
-                async with lock:
-                    snapshot = session.messages[session.last_consolidated:]
-                    if snapshot:
-                        temp = Session(key=session.key)
-                        temp.messages = list(snapshot)
-                        if not await self._consolidate_memory(temp, archive_all=True):
-                            return OutboundMessage(
-                                channel=msg.channel, chat_id=msg.chat_id,
-                                content="Memory archival failed, session not cleared. Please try again.",
-                            )
-            except Exception:
-                logger.exception("/new archival failed for {}", session.key)
-                return OutboundMessage(
-                    channel=msg.channel, chat_id=msg.chat_id,
-                    content="Memory archival failed, session not cleared. Please try again.",
-                )
-            finally:
-                self._consolidating.discard(session.key)
-
+            self._consolidating.discard(session.key)
+            MemoryStore(self.workspace).reset()
             session.clear()
             self.sessions.save(session)
             self.sessions.invalidate(session.key)

--- a/0xclaw/runtime/agent/memory.py
+++ b/0xclaw/runtime/agent/memory.py
@@ -45,6 +45,23 @@ _SAVE_MEMORY_TOOL = [
 class MemoryStore:
     """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
 
+    DEFAULT_MEMORY_TEMPLATE = """# Long-term Memory
+
+This file stores stable user information that should persist across sessions.
+
+## User Information
+
+(Important facts about the user)
+
+## Preferences
+
+(Stable preferences like language, tone, frameworks, or tooling)
+
+## Important Notes
+
+(Only durable facts worth carrying across conversations)
+"""
+
     def __init__(self, workspace: Path):
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
@@ -61,6 +78,12 @@ class MemoryStore:
     def append_history(self, entry: str) -> None:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
+
+    def reset(self) -> None:
+        """Reset both memory files to an empty session-safe state."""
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        self.memory_file.write_text(self.DEFAULT_MEMORY_TEMPLATE + "\n", encoding="utf-8")
+        self.history_file.write_text("", encoding="utf-8")
 
     def get_memory_context(self) -> str:
         long_term = self.read_long_term()
@@ -103,6 +126,11 @@ class MemoryStore:
 
         current_memory = self.read_long_term()
         prompt = f"""Process this conversation and call the save_memory tool with your consolidation.
+
+Only preserve durable cross-session memory. Keep long-term memory limited to stable user preferences,
+ongoing identity-level facts, and enduring project conventions. Do NOT store transient hackathon state,
+phase progress, generated artifacts, temporary research findings, or task-specific implementation status.
+Those belong in workspace output files, not long-term memory.
 
 ## Current Long-term Memory
 {current_memory or "(empty)"}

--- a/0xclaw/runtime/skills/memory/SKILL.md
+++ b/0xclaw/runtime/skills/memory/SKILL.md
@@ -21,11 +21,18 @@ Use the `exec` tool to run grep. Combine patterns: `grep -iE "meeting|deadline" 
 
 ## When to Update MEMORY.md
 
-Write important facts immediately using `edit_file` or `write_file`:
-- User preferences ("I prefer dark mode")
-- Project context ("The API uses OAuth2")
-- Relationships ("Alice is the project lead")
+Write only durable cross-session facts:
+- User preferences ("I prefer Chinese", "Use FastAPI by default")
+- Stable working conventions ("Prefer pytest", "Use pnpm in this repo family")
+- Long-lived relationships ("Alice is the project lead")
+
+Do NOT write transient execution state:
+- Hackathon research results
+- Current pipeline phase or task progress
+- Generated artifact lists
+- Temporary implementation/debug status
+- Anything that should reset with `/new`
 
 ## Auto-consolidation
 
-Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts are extracted to MEMORY.md. You don't need to manage this.
+Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts may be extracted to MEMORY.md, but only durable preferences and enduring facts belong there.

--- a/workspace/skills/hackathon-research/SKILL.md
+++ b/workspace/skills/hackathon-research/SKILL.md
@@ -23,7 +23,6 @@ Do not ask clarifying questions. Proceed autonomously through all steps.
 
 Step 1 — Load existing workspace context (do this first):
   read_file("AGENTS.md")
-  read_file("memory/MEMORY.md")
   read_file("SOUL.md")
 
 Step 2 — Fetch the hackathon pages using web_fetch:


### PR DESCRIPTION
Fix /new so a fresh session no longer leaks old conversation or memory state into the next turn. 
Add request-scoped CLI turn handling so delayed responses like New session started. do not bleed into later prompts. 
Reset workspace/memory/MEMORY.md and workspace/memory/HISTORY.md on /new instead of archiving transient hackathon state. 
Restrict long-term memory to durable user preferences and stable conventions only. Reconcile pipeline_state.json against real hackathon artifacts before /status, /resume, and phase validation. 
Make planning completion require both plan.md and tasks.json, matching coding dependencies.
 Prevent non-phase writes to protected hackathon/ pipeline artifacts through the phase write guard. Hydrate legacy or partial pipeline_state.json files so missing phase rows no longer crash /resume.