### PR TITLE
Align README and CLAUDE.md model docs with model_profiles.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ CI runs on push/PR to master: `ruff check tests` + `python -m unittest discover`
 
 | Key | Purpose | Notes |
 |-----|---------|-------|
-| `ZAI_API_KEY` | Primary LLM via Z.ai (international) | `zhipu` provider in config; model `glm-4.5` |
+| `ZAI_API_KEY` | Primary LLM via Z.ai (international) | `zhipu` provider in config; default model `glm-5.1` (see `0xclaw/config/model_profiles.json` for per-phase overrides) |
 | `FLOCK_API_KEY` | Secondary LLM via FLock.io | HTTP 400 = budget exhausted |
 | `BRAVE_API_KEY` | Web search | Optional |
 
@@ -168,7 +168,7 @@ applies to `exec()` working directory.
 ### Z.ai (primary LLM — `provider: "zhipu"`)
 - Endpoint: `https://api.z.ai/api/paas/v4` (international; NOT bigmodel.cn)
 - Auth: `ZAI_API_KEY` via standard Bearer token
-- Default model: `glm-4.5` (`config.json`); all 7 phases use `glm-4.5` (`model_profiles.json`)
+- Default model: `glm-5.1` (`config.json`). Per-phase overrides in `model_profiles.json`: `research` and `coding` use `glm-5.1`; `idea`, `selection`, `planning`, `testing`, and `doc` use `glm-4.5`
 - OpenAI-compatible API; LiteLLM routes as `zai/<model>` automatically
 - Configured under both `zhipu` and `custom` keys in `config.json` (identical settings)
 - If `README.md` and `model_profiles.json` disagree on the default model, `model_profiles.json` is authoritative — README may be stale

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ Inference powered by **FLock.io** and **Z.AI**
 
 <div align="center">
 <table>
-<tr><th>Phases</th><th>Model</th><th>Context</th></tr>
-<tr><td>research · idea · selection · doc</td><td><code>minimax-m2.1</code></td><td>196k</td></tr>
-<tr><td>planning · coding · testing</td><td><code>minimax-m2.5</code></td><td>205k</td></tr>
+<tr><th>Phases</th><th>Model</th></tr>
+<tr><td>research · coding</td><td><code>glm-5.1</code></td></tr>
+<tr><td>idea · selection · planning · testing · doc</td><td><code>glm-4.5</code></td></tr>
 </table>
 </div>
 
-Per-phase timeout and fallback behavior are defined in `0xclaw/config/model_profiles.json` (source of truth).
+Per-phase model, timeout, and token settings are defined in `0xclaw/config/model_profiles.json` (source of truth).
 
 ## 💬 Channels
 


### PR DESCRIPTION
The README Models table referenced `minimax-m2.1`/`minimax-m2.5`, which do not exist anywhere in the codebase, and grouped phases incorrectly. CLAUDE.md claimed `glm-4.5` is the default and that all 7 phases share that model, which has been false since `Restore glm-5.1 for research and coding phases` (commit 511ecec).

Aligned both to the current `0xclaw/config/model_profiles.json`:
  - research, coding -> glm-5.1
  - idea, selection, planning, testing, doc -> glm-4.5
  - default model in `config.json` is glm-5.1

Removed the README "Context" column whose `196k`/`205k` values were tied to the fictitious `minimax-m2.x` names and have no source of truth in the repo. `model_profiles.json` is now the documented single source of truth for per-phase model selection.